### PR TITLE
Gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# IntelliJ Idea
+.idea/
+
+# VS Code
+.vscode/
+
+# metals
+.metals/
+.bloop/
+.ammonite/
+metals.sbt
+
+# sbt
+target/
+
+# mill
+out/
+
+# Scala
+.bsp/
+.scala-build/
+
+# Misc
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,14 @@ out/
 *.iws
 
 # VS Code
-.vscode/
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+## Local History for Visual Studio Code
+.history/
 
 # metals
 .metals/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # IntelliJ Idea
-out/
 ## User-specific stuff
 .idea/**/workspace.xml
 .idea/**/tasks.xml

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ out/
 .metals/
 .bloop/
 .ammonite/
-metals.sbt
+project/**/metals.sbt
 
 # sbt
 target/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,23 @@
 # IntelliJ Idea
-.idea/
+out/
+## User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+## Generated files
+.idea/**/contentModel.xml
+## Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+## File-based project format
+*.iws
 
 # VS Code
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -51,8 +51,9 @@ project/plugins/project/
 out/
 
 # Scala
-.bsp/
 .scala-build/
+*.class
+*.log
 
 # Misc
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,6 @@ out/
 # Scala
 .scala-build/
 *.class
-*.log
 
 # Misc
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,16 @@ out/
 project/**/metals.sbt
 
 # sbt
+dist/*
 target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+.history
+.cache
+.lib/
+.bsp/
 
 # mill
 out/


### PR DESCRIPTION
I added a bunch of things which I think might be useful. Little corrections for corner cases that should encompass a wide range of use cases.

IntelliJ is annoying, there are a lot of files that are very useful when collaborating. Too many. So I'm ignoring the files which we know for sure should be gone.

VSCode has the opposite problem. Most files should be ignored, except for those that help with various tasks and debugging (which in my experience are better when shared).

For Metals, I've had situations where I've had to make a metals specific build file for something that had to be rushed. I think it's better to avoid confusion?

SBT generates a lot of garbage, so hopefully I'm getting rid of most of that.

And last but not least, `.class` files should not be committed :D

This is usually what I start my new scala projects with (with some further additions that are specific to my setup) and then I add or remove when necessary. However, it might be too much.

Except for most of the one in IntelliJ. It's a pain, but I believe it's a necessity. I've had multiple instances where regenerating files in `.idea` broke large portions of the project and had to fix by hand. Although it has taught me a ton, I don't recommend it to anyone :D